### PR TITLE
fix: fix CVE-2026-33845, CVE-2026-33846, CVE-2026-42009, CVE-2026-420…

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,17 @@
+gnutls28 (3.7.9-2+deb12u5deepin3) unstable; urgency=high
+
+  * Fix CVE-2026-33845: DTLS handshake reassembly heap overrun (CVSS 7.5
+    High)
+  * Fix CVE-2026-33846: DTLS reassembly consistency checks (CVSS 7.5
+    High)
+  * Fix CVE-2026-42010: RSA-PSK binary PSK identity lookup (CVSS 7.1
+    High)
+  * Fix CVE-2026-42009: DTLS datagram sequence number matching
+  * Fix CVE-2026-42011: X.509 name constraints intersecting empty
+    constraints (CVSS 4.8)
+
+ -- lichenggang <lichenggang@uniontech.com>  Wed, 13 May 2026 11:41:32 +0800
+
 gnutls28 (3.7.9-2+deb12u5deepin2) unstable; urgency=medium
 
   * pkcs11: avoid stack overwrite when initializing a token

--- a/debian/patches/70-buffers-switch-from-end_offset-to-frag_length.patch
+++ b/debian/patches/70-buffers-switch-from-end_offset-to-frag_length.patch
@@ -1,0 +1,190 @@
+From: Alexander Sosedkin <asosedkin@redhat.com>
+Subject: buffers: switch from end_offset over to frag_length
+Bug: https://gitlab.com/gnutls/gnutls/-/issues/1811
+Origin: https://gitlab.com/gnutls/gnutls/-/commit/e5b72c53c7d789d19d1d1cd10b275e87d0415413
+Applied-upstream: 3.8.11
+CVE: CVE-2026-33845
+
+Instead of maintaining an inclusive [start_offset, end_offset] range
+when reassembling DTLS handshake,
+track start_offset and a relative frag_length instead.
+
+This fixes:
+* 0-length fragments triggering completion if message was 1 byte long
+* a remotely triggerable underflow and an ensuing heap overrun
+
+Reported-by: Joshua Rogers of AISLE Research Team <joshua@joshua.hu>
+Fixes: #1811
+Fixes: CVE-2026-33845
+Fixes: GNUTLS-SA-2026-04-29-3
+CVSS: 7.5 High CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:H
+
+Adapted for gnutls28 3.7.9 by lichenggang.
+
+--- a/lib/gnutls_int.h	2026-05-13 13:52:52.239235600 +0800
++++ b/lib/gnutls_int.h	2026-05-13 13:52:55.743308117 +0800
+@@ -398,10 +398,10 @@
+ 	uint16_t sequence;
+ 
+ 	/* indicate whether that message is complete.
+-	 * complete means start_offset == 0 and end_offset == length
++	 * complete means start_offset == 0 and frag_length == length
+ 	 */
+ 	uint32_t start_offset;
+-	uint32_t end_offset;
++	uint32_t frag_length; /* used exclusively in DTLS reassembly */
+ 
+ 	uint8_t header[MAX_HANDSHAKE_HEADER_SIZE];
+ 	int header_size;
+
+--- a/lib/buffers.c	2026-05-13 13:52:52.243235682 +0800
++++ b/lib/buffers.c	2026-05-13 13:56:26.787673159 +0800
+@@ -961,10 +961,7 @@
+ 	}
+ 	data_size = _mbuffer_get_udata_size(bufel) - handshake_header_size;
+ 
+-	if (frag_size > 0)
+-		hsk->end_offset = hsk->start_offset + frag_size - 1;
+-	else
+-		hsk->end_offset = 0;
++	hsk->frag_length = frag_size;
+ 
+ 	_gnutls_handshake_log
+ 	    ("HSK[%p]: %s (%u) was received. Length %d[%d], frag offset %d, frag length: %d, sequence: %d\n",
+@@ -977,14 +974,15 @@
+ 	memcpy(hsk->header, _mbuffer_get_udata_ptr(bufel),
+ 	       handshake_header_size);
+ 
+-	if (hsk->length > 0 && (frag_size > data_size ||
+-				(frag_size > 0 &&
+-				 hsk->end_offset >= hsk->length))) {
++	if (hsk->length > 0 &&
++        (frag_size > data_size ||
++	     (frag_size > 0 &&
++	      hsk->start_offset + frag_size > hsk->length))) {
+ 		return
+ 		    gnutls_assert_val(GNUTLS_E_UNEXPECTED_PACKET_LENGTH);
+-	}
+-	else if (hsk->length == 0 && hsk->end_offset != 0
+-		 && hsk->start_offset != 0)
++	} else if (hsk->length == 0 &&
++		   hsk->start_offset + frag_size != hsk->start_offset &&
++           hsk->start_offset != 0)
+ 		return
+ 		    gnutls_assert_val(GNUTLS_E_UNEXPECTED_PACKET_LENGTH);
+ 
+@@ -1026,9 +1024,8 @@
+ 		    gnutls_assert_val(GNUTLS_E_TOO_MANY_HANDSHAKE_PACKETS);
+ 
+ 	if (!exists) {
+-		if (hsk->length > 0 && hsk->end_offset > 0
+-		    && hsk->end_offset - hsk->start_offset + 1 !=
+-		    hsk->length) {
++		if (hsk->length > 0 && hsk->frag_length > 0 &&
++		    hsk->frag_length != hsk->length) {
+ 			ret =
+ 			    _gnutls_buffer_resize(&hsk->data, hsk->length);
+ 			if (ret < 0)
+@@ -1037,8 +1034,7 @@
+ 			hsk->data.length = hsk->length;
+ 
+ 			memmove(&hsk->data.data[hsk->start_offset],
+-				hsk->data.data,
+-				hsk->end_offset - hsk->start_offset + 1);
++				hsk->data.data, hsk->frag_length);
+ 		}
+ 
+ 		session->internals.handshake_recv_buffer_size++;
+@@ -1055,8 +1051,8 @@
+ 	} else {
+ 		if (hsk->start_offset <
+ 		    session->internals.handshake_recv_buffer[pos].
+-		    start_offset
+-		    && hsk->end_offset + 1 >=
++		    start_offset &&
++		    hsk->start_offset + hsk->frag_length >=
+ 		    session->internals.handshake_recv_buffer[pos].
+ 		    start_offset) {
+ 			memcpy(&session->internals.
+@@ -1066,28 +1062,35 @@
+ 			session->internals.handshake_recv_buffer[pos].
+ 			    start_offset = hsk->start_offset;
+ 			session->internals.handshake_recv_buffer[pos].
+-			    end_offset =
+-			    MIN(hsk->end_offset,
+-				session->internals.
+-				handshake_recv_buffer[pos].end_offset);
+-		} else if (hsk->end_offset >
++			    frag_length = MIN(
++				hsk->frag_length,
++				session->internals.handshake_recv_buffer[pos].
++				frag_length);
++		} else if (hsk->start_offset + hsk->frag_length >
++			   session->internals.handshake_recv_buffer[pos].
++			   start_offset +
++			   session->internals.handshake_recv_buffer[pos].
++			   frag_length &&
++			   hsk->start_offset <=
+ 			   session->internals.handshake_recv_buffer[pos].
+-			   end_offset
+-			   && hsk->start_offset <=
++			   start_offset +
+ 			   session->internals.handshake_recv_buffer[pos].
+-			   end_offset + 1) {
++			   frag_length) {
+ 			memcpy(&session->internals.
+ 			       handshake_recv_buffer[pos].data.data[hsk->
+ 								    start_offset],
+ 			       hsk->data.data, hsk->data.length);
+ 
+ 			session->internals.handshake_recv_buffer[pos].
+-			    end_offset = hsk->end_offset;
+-			session->internals.handshake_recv_buffer[pos].
+ 			    start_offset =
+ 			    MIN(hsk->start_offset,
+ 				session->internals.
+ 				handshake_recv_buffer[pos].start_offset);
++			session->internals.handshake_recv_buffer[pos].
++			    frag_length = hsk->start_offset +
++			    hsk->frag_length -
++			    session->internals.handshake_recv_buffer[pos].
++			    start_offset;
+ 		}
+ 		_gnutls_handshake_buffer_clear(hsk);
+ 	}
+@@ -1148,9 +1151,9 @@
+ 		}
+ 
+ 		else if ((recv_buf[LAST_ELEMENT].start_offset == 0 &&
+-			  recv_buf[LAST_ELEMENT].end_offset ==
+-			  recv_buf[LAST_ELEMENT].length - 1)
+-			 || recv_buf[LAST_ELEMENT].length == 0) {
++			  recv_buf[LAST_ELEMENT].frag_length ==
++			  recv_buf[LAST_ELEMENT].length) ||
++			 recv_buf[LAST_ELEMENT].length == 0) {
+ 			session->internals.dtls.hsk_read_seq++;
+ 			_gnutls_handshake_buffer_move(hsk,
+ 						      &recv_buf
+@@ -1161,7 +1164,9 @@
+ 			/* if we don't have a complete handshake message, but we
+ 			 * have queued data waiting, try again to reconstruct the
+ 			 * handshake packet, using the queued */
+-			if (recv_buf[LAST_ELEMENT].end_offset != recv_buf[LAST_ELEMENT].length - 1 &&
++			if ((recv_buf[LAST_ELEMENT].start_offset +
++			     recv_buf[LAST_ELEMENT].frag_length) !=
++			    recv_buf[LAST_ELEMENT].length &&
+ 			    record_check_unprocessed(session) > 0)
+ 				return gnutls_assert_val(GNUTLS_E_INT_CHECK_AGAIN);
+ 			else
+@@ -1348,10 +1353,7 @@
+ 						 record_buffer, bufel,
+ 						 ret);
+ 
+-				data_size =
+-				    MIN(tmp.length,
+-					tmp.end_offset - tmp.start_offset +
+-					1);
++				data_size = MIN(tmp.length, tmp.frag_length);
+ 
+ 				ret =
+ 				    _gnutls_buffer_append_data(&tmp.data,

--- a/debian/patches/71-x509-name_constraints-fix-intersect-over-sorted.patch
+++ b/debian/patches/71-x509-name_constraints-fix-intersect-over-sorted.patch
@@ -1,0 +1,33 @@
+From: Alexander Sosedkin <asosedkin@redhat.com>
+Subject: x509/name_constraints: fix intersecting empty constraints
+Bug: https://gitlab.com/gnutls/gnutls/-/issues/1824
+Origin: https://gitlab.com/gnutls/gnutls/-/commit/1dead2faec6320aaba321eb56f20d442df192b83
+Applied-upstream: 3.8.11
+CVE: CVE-2026-42011
+
+Permitted name constraints were wrongfully ignored
+when prior CAs only had excluded name constraints,
+resulting in a name constraint bypass.
+
+With this change, they are taken into account and propagate.
+
+Reported-by: Haruto Kimura (Stella)
+Fixes: #1824
+Fixes: CVE-2026-42011
+Fixes: GNUTLS-SA-2026-04-29-6
+CVSS: 4.8 Medium CVSS:3.1/AV:N/AC:H/PR:N/UI:N/S:U/C:L/I:L/A:N
+
+Adapted for gnutls28 3.7.9 (on top of patch 65) by lichenggang.
+
+--- a/lib/x509/name_constraints.c	2026-05-13 14:34:58.764204497 +0800
++++ b/lib/x509/name_constraints.c	2026-05-13 14:35:42.909156768 +0800
+@@ -348,9 +348,6 @@
+ 	memset(types_with_empty_intersection, 0,
+ 	       sizeof(types_with_empty_intersection));
+ 
+-	if (permitted->size == 0 || permitted2->size == 0)
+-		return 0;
+-
+ 	/* Phase 1
+ 	 * For each name in PERMITTED, if a PERMITTED2 does not contain a name
+ 	 * with the same type, move the original name to REMOVED.

--- a/debian/patches/72-rsa_psk-fix-binary-PSK-identity-lookup.patch
+++ b/debian/patches/72-rsa_psk-fix-binary-PSK-identity-lookup.patch
@@ -1,0 +1,29 @@
+From: Alexander Sosedkin <asosedkin@redhat.com>
+Subject: lib/auth/rsa_psk: fix binary PSK identity lookup
+Origin: https://gitlab.com/gnutls/gnutls/-/commit/cb1833afd9b6309563211b1c0a7c291f52ca98d5
+Applied-upstream: 3.8.11
+CVE: CVE-2026-42010
+
+A server looking up PSK username with a NUL-character in it
+was wrongfully matching username truncated at a NUL-character.
+Fix the check to compare up to the full username length.
+
+Reported-by: Joshua Rogers of AISLE Research Team <joshua@joshua.hu>
+Fixes: #1850
+Fixes: CVE-2026-42010
+Fixes: GNUTLS-SA-2026-04-29-4
+CVSS: 7.1 High CVSS:3.1/AV:N/AC:L/PR:L/UI:N/S:U/C:H/I:L/A:N
+
+Adapted for gnutls28 3.7.9 by lichenggang.
+
+--- a/lib/auth/rsa_psk.c	2026-05-13 14:36:41.282412015 +0800
++++ b/lib/auth/rsa_psk.c	2026-05-13 14:36:41.286412100 +0800
+@@ -334,7 +334,7 @@
+ 	 * filled in if the key is not found.
+ 	 */
+ 	ret = _gnutls_psk_pwd_find_entry(session, info->username,
+-					 strlen(info->username), &pwd_psk);
++					 info->username_len, &pwd_psk);
+ 	if (ret < 0)
+ 		return gnutls_assert_val(ret);
+ 

--- a/debian/patches/73-buffers-add-more-checks-to-DTLS-reassembly.patch
+++ b/debian/patches/73-buffers-add-more-checks-to-DTLS-reassembly.patch
@@ -1,0 +1,57 @@
+From: Alexander Sosedkin <asosedkin@redhat.com>
+Subject: buffers: add more checks to DTLS reassembly
+Origin: https://gitlab.com/gnutls/gnutls/-/commit/65ab33fa54e34fba69d793735b7df3d383d1ff78
+Applied-upstream: 3.8.11
+CVE: CVE-2026-33846
+Depends: 70-buffers-switch-from-end_offset-to-frag_length.patch
+
+Previously, gnutls didn't check that DTLS fragments claimed
+a consistent message_length value.
+Additionally, a crucial array size check was missing,
+enabling an attacker to cause a heap overwrite.
+The updated version rejects fragments with mismatching length
+and adds a missing boundary check.
+
+Reported-by: Haruto Kimura (Stella)
+Reported-by: Oscar Reparaz
+Reported-by: Zou Dikai
+Fixes: #1816
+Fixes: #1838
+Fixes: #1839
+Fixes: CVE-2026-33846
+Fixes: GNUTLS-SA-2026-04-29-1
+CVSS: 7.4 High CVSS:3.1/AV:N/AC:H/PR:N/UI:N/S:U/C:N/I:H/A:H
+CVSS: 7.5 High CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:N/I:N/A:H
+
+Adapted for gnutls28 3.7.9 (on top of CVE-2026-33845 frag_length patch) by lichenggang.
+
+--- a/lib/buffers.c	2026-05-13 14:01:38.626246770 +0800
++++ b/lib/buffers.c	2026-05-13 14:03:18.664390218 +0800
+@@ -1049,6 +1049,27 @@
+ 					      hsk);
+ 
+ 	} else {
++		if (hsk->length !=
++		    session->internals.handshake_recv_buffer[pos].length) {
++			/* inconsistent across fragments */
++			_gnutls_handshake_buffer_clear(hsk);
++			return gnutls_assert_val(
++				GNUTLS_E_UNEXPECTED_PACKET_LENGTH);
++		}
++		if (hsk->data.length >
++		    session->internals.handshake_recv_buffer[pos]
++		    .data.max_length) {
++			/* would overwrite if merged */
++			_gnutls_handshake_buffer_clear(hsk);
++			return gnutls_assert_val(
++				GNUTLS_E_UNEXPECTED_PACKET_LENGTH);
++		}
++		if (session->internals.handshake_recv_buffer_size >=
++		    MAX_HANDSHAKE_MSGS) {
++			_gnutls_handshake_buffer_clear(hsk);
++			return gnutls_assert_val(
++				GNUTLS_E_TOO_MANY_HANDSHAKE_PACKETS);
++		}
+ 		if (hsk->start_offset <
+ 		    session->internals.handshake_recv_buffer[pos].
+ 		    start_offset &&

--- a/debian/patches/74-buffers-match-DTLS-datagrams-by-sequence-number.patch
+++ b/debian/patches/74-buffers-match-DTLS-datagrams-by-sequence-number.patch
@@ -1,0 +1,45 @@
+From: Alexander Sosedkin <asosedkin@redhat.com>
+Subject: buffers: match DTLS datagrams by sequence number
+Origin: https://gitlab.com/gnutls/gnutls/-/commit/092c65d004e2f125f2fea3db84d801ac49a09f78
+Applied-upstream: 3.8.11
+CVE: CVE-2026-42009
+
+DTLS handshake fragment reassembly previously matched incoming fragments
+by handshake type only, without checking the sequence number.
+This allowed fragments from different handshake messages
+to be merged into the same reassembly buffer.
+
+Now sequence number is accounted for during reassembly,
+ensuring fragments are only merged when they belong
+to the same handshake message.
+
+Additionally fix handshake_compare qsort comparator to use strict <
+instead of <= when comparing sequence numbers, violating qsort contract.
+
+Reported-by: Zou Dikai
+Fixes: #1839
+Fixes: CVE-2026-42009
+
+Adapted for gnutls28 3.7.9 by lichenggang.
+
+--- a/lib/buffers.c
++++ b/lib/buffers.c
+@@ -884,7 +884,7 @@ static int handshake_compare(const void *_e1, const void *_e2)
+ 	const handshake_buffer_st *e1 = _e1;
+ 	const handshake_buffer_st *e2 = _e2;
+
+-	if (e1->sequence <= e2->sequence)
++	if (e1->sequence < e2->sequence)
+ 		return 1;
+ 	else
+ 		return -1;
+@@ -1011,7 +1011,8 @@ static int merge_handshake_packet(gnutls_session_t session,
+
+ 	for (i = 0; i < session->internals.handshake_recv_buffer_size; i++) {
+ 		if (session->internals.handshake_recv_buffer[i].htype ==
+-		    hsk->htype) {
++		    hsk->htype &&
++		    session->internals.handshake_recv_buffer[i].sequence == hsk->sequence) {
+ 			exists = 1;
+ 			pos = i;
+ 			break;

--- a/debian/patches/series
+++ b/debian/patches/series
@@ -22,5 +22,10 @@
 69_0004-x509-avoid-double-free-when-exporting-othernames-in-.patch
 69_0005-certtool-avoid-1-byte-write-buffer-overrun-when-pars.patch
 69_0006-handshake-clear-HSK_PSK_SELECTED-is-when-resetting-b.patch
+70-buffers-switch-from-end_offset-to-frag_length.patch
+71-x509-name_constraints-fix-intersect-over-sorted.patch
+72-rsa_psk-fix-binary-PSK-identity-lookup.patch
+73-buffers-add-more-checks-to-DTLS-reassembly.patch
+74-buffers-match-DTLS-datagrams-by-sequence-number.patch
 0025-pkcs11-avoid-stack-overwrite-when-initializing-a-tok.patch
 uniontech-adapter-hygon.patch


### PR DESCRIPTION
    fix: fix CVE-2026-33845, CVE-2026-33846, CVE-2026-42009, CVE-2026-42010 and CVE-2026-42011
    
    Fix five security vulnerabilities in gnutls28:
    
    1. CVE-2026-33845 (CVSS 7.5 High): DTLS handshake reassembly heap overrun
       - Switch from end_offset to frag_length in handshake buffer tracking
       - Fixes 0-length fragments triggering completion and remotely triggerable underflow
       - Reference: GNUTLS-SA-2026-04-29-3
    
    2. CVE-2026-33846 (CVSS 7.5 High): DTLS reassembly consistency checks
       - Reject fragments with mismatching message_length values
       - Add missing array boundary check to prevent heap overwrite
       - Reference: GNUTLS-SA-2026-04-29-1
    
    3. CVE-2026-42009: DTLS datagram sequence number matching
       - Match DTLS fragments by both handshake type AND sequence number
       - Fix handshake_compare qsort comparator (strict < instead of <=)
    
    4. CVE-2026-42010 (CVSS 7.1 High): RSA-PSK binary PSK identity lookup
       - Fix PSK username lookup using strlen() which truncates at NUL bytes
       - Use info->username_len to handle binary PSK identities correctly
       - Reference: GNUTLS-SA-2026-04-29-4
    
    5. CVE-2026-42011 (CVSS 4.8 Medium): X.509 name constraints intersecting empty constraints
       - Fix permitted name constraints being ignored when prior CAs only had excluded constraints
       - Remove wrongful early-return guard in _gnutls_name_constraints_intersect
       - Reference: GNUTLS-SA-2026-04-29-6
    
    All patches adapted from upstream GitLab to gnutls28 (Debian 3.7.9).
    
    Log: Fix CVE-2026-33845, CVE-2026-33846, CVE-2026-42009, CVE-2026-42010, CVE-2026-42011
    
    Influence:
    1. Test DTLS handshake reassembly with fragmented messages
    2. Verify RSA-PSK authentication with binary PSK identities containing NUL bytes
    3. Check DTLS fragment merging with different sequence numbers
    4. Validate X.509 certificate chain validation with name constraints
    5. Ensure no regression in TLS/DTLS connection establishment
    
    fix: 修复 CVE-2026-33845、CVE-2026-33846、CVE-2026-42009、CVE-2026-42010 和 CVE-2026-42011
    
    修复 gnutls28 中的五个安全漏洞:
    
    1. CVE-2026-33845 (CVSS 7.5 高危): DTLS 握手重组堆溢出
       - 将握手缓冲区跟踪从 end_offset 切换为 frag_length
       - 修复 0 长度分片触发完成和可远程触发的下溢
       - 参考: GNUTLS-SA-2026-04-29-3
    
    2. CVE-2026-33846 (CVSS 7.5 高危): DTLS 重组一致性检查
       - 拒绝 message_length 不一致的分片
       - 添加缺失的数组边界检查以防止堆覆写
       - 参考: GNUTLS-SA-2026-04-29-1
    
    3. CVE-2026-42009: DTLS 数据报序列号匹配
       - 同时按握手类型和序列号匹配 DTLS 分片
       - 修复 handshake_compare qsort 比较器 (严格 < 替代 <=)
    
    4. CVE-2026-42010 (CVSS 7.1 高危): RSA-PSK 二进制 PSK 身份查找
       - 修复使用 strlen() 查找 PSK 用户名时在 NUL 字节处截断的问题
       - 使用 info->username_len 正确处理二进制 PSK 身份
       - 参考: GNUTLS-SA-2026-04-29-4
    
    5. CVE-2026-42011 (CVSS 4.8 中危): X.509 名称约束交叉空约束
       - 修复前序 CA 仅有排除约束时许可名称约束被忽略的问题
       - 移除 _gnutls_name_constraints_intersect 中错误的提前返回守卫
       - 参考: GNUTLS-SA-2026-04-29-6
    
    所有补丁从上游 GitLab 适配到 gnutls28 (Debian 3.7.9)。
    
    Log: 修复 CVE-2026-33845、CVE-2026-33846、CVE-2026-42009、CVE-2026-42010、CVE-2026-42011
    
    Influence:
    1. 测试分片消息的 DTLS 握手重组
    2. 验证含 NUL 字节的二进制 PSK 身份的 RSA-PSK 认证
    3. 检查不同序列号下的 DTLS 分片合并
    4. 验证带名称约束的 X.509 证书链验证
    5. 确保 TLS/DTLS 连接建立无回归
    
    repo: gnutls28 #master
